### PR TITLE
Pin the Fedora base image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:38
 
 RUN dnf update -y && \
     dnf install wget git meson cmake gcc gcc-c++ \


### PR DESCRIPTION
I would like to use the `gtk4-rs` image to do container builds of Relm4 / GTK apps on GitHub Actions.

In the interest of reproducibility of CI builds, I thought it might be best if the Fedora base image version in `gtk-rs-core` is pinned to a fixed version rather than just `latest` (which is a moving target). I have therefore pinned it to `38`.